### PR TITLE
Bugfix: audio on Safari now plays correctly

### DIFF
--- a/src/hooks/useAudio.tsx
+++ b/src/hooks/useAudio.tsx
@@ -14,6 +14,7 @@ export default function useAudio(src: string) {
     // Wait ~10 ms for audio to fade out before restarting
     setTimeout(() => {
       clearInterval(interval);
+      audio.load();
       audio.volume = 1;
       audio.currentTime = 0;
       audio.play();


### PR DESCRIPTION
This PR closes issue #2 by explicitly calling the `audio.load()` method in the `useAudio()` hook just before the a sound is about to be restarted