### PR TITLE
Bugfix: updated styles at narrow screen widths

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,7 +4,7 @@ import { githubLogoSvgData } from "../../public/graphics";
 export default function Footer() {
   return (
     <footer
-      className="text-center h-8 bg-red-800 text-white font-thin"
+      className="text-center h-4 xs:h-8 text-xs bg-red-800 text-white font-thin"
       aria-label="footer"
     >
       <span>Made with love by </span>

--- a/src/components/InformationModal.tsx
+++ b/src/components/InformationModal.tsx
@@ -10,7 +10,7 @@ export default function InformationModal() {
     <>
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="h-full aspect-square p-1 sm:p-2 bg-red-800 hover:bg-red-700 focus-visible:ring ring-black focus:bg-red-700 transition-color outline-none "
+        className="h-full hidden xs:block aspect-square p-1 sm:p-2 bg-red-800 hover:bg-red-700 focus-visible:ring ring-black focus:bg-red-700 transition-color outline-none "
         aria-label="Open Application Instructions"
         role="button"
       >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,22 +13,22 @@ export default function Home() {
   const { showKeybinds, setShowKeybinds, laras, setLaras } = state;
 
   return (
-    <div className="flex flex-col w-screen h-screen">
+    <div className="flex flex-col w-screen h-screen overflow-hidden">
       <Seo />
       <header
-        className="flex justify-between h-8 sm:h-12"
+        className="flex justify-between h-8 sm:h-12 bg-red-800"
         aria-label="Application Header & Settings"
       >
         {/* Left side of banner */}
-        <div className="flex flex-row">
-          <h1 className="inline align-middle whitespace-nowrap uppercase font-thing h-full tracking-wider sm:text-xl sm:pt-2 p-1 bg-red-800 px-4 text-white">
+        <div className="flex flex-row w-full">
+          <h1 className="inline align-middle whitespace-nowrap uppercase font-bold h-full sm:text-xl sm:pt-2 p-1 bg-red-800 px-4 text-white">
             Virtual Bonang
           </h1>
           <InformationModal />
         </div>
 
         {/* Right side of banner */}
-        <div className="flex flex-row bg-red-800">
+        <div className="flex-row bg-red-800 hidden xs:flex">
           <KeybindVisibilityToggle state={{ showKeybinds, setShowKeybinds }} />
           <LarasSelector state={{ laras, setLaras }} />
         </div>
@@ -41,8 +41,9 @@ export default function Home() {
         <Bonang state={state} />
       </main>
 
-      <main className="mb-auto mt-auto block text-center text-3xl xs:hidden landscape:hidden">
-        Please orientate your device wide
+      <main className="mb-auto p-2 mt-auto block  uppercase font-bold text-center  xs:hidden landscape:hidden">
+        <p className="text-3xl font-sans">Please orientate your device wide</p>
+        <p className="mt-2 tracking-tight">The bonang is a wide instrument</p>
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
This PR closes #3 by updating the styling of elements at small screen sizes. Info, keybind, and laras selectors have been hidden, and the header and footers have been resized

<img width="333" alt="screenshot of updated virtual bonang website at a narrow screenwidth" src="https://github.com/calumbell/virtual-bonang/assets/47755775/d1707e0a-af11-41df-a82d-b5f4f6939412">
