### PR TITLE
Refactored font loading using next/font/local

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,18 @@
-import '@/styles/globals.css'
-import type { AppProps } from 'next/app'
+import "@/styles/globals.css";
+import type { AppProps } from "next/app";
+
+// configure kepatihan font
+import localFont from "next/font/local";
+const kepatihanFont = localFont({
+  src: "../../public/fonts/kepatihan.ttf",
+  weight: "400",
+  variable: "--font-kepatihan",
+});
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <main className={kepatihanFont.variable}>
+      <Component {...pageProps} />
+    </main>
+  );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,8 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@font-face {
-  font-family: kepatihan;
-  src: local(kepatihan), url("/public/fonts/kepatihan.ttf") format("tff");
-}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,7 +15,7 @@ module.exports = {
         pulse: "pulse 0.1s ease-in-out",
       },
       fontFamily: {
-        kepatihan: ["KepatihanPro"],
+        kepatihan: ["var(--font-kepatihan)"],
       },
       keyframes: {
         pulse: {


### PR DESCRIPTION
This PR closes #1 by refactoring the code used to load the local Kepatihan font files using the `next/font/local` package. Following these changes, the font appears to be loading across all browsers