### PR TITLE
implemented useAudioContext() hook

### DIFF
--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -1,7 +1,15 @@
 import useAnimation from "./useAnimation";
+import useAudioContext from "./useAudioContext";
 import useAppState from "./useAppState";
 import useAudio from "./useAudio";
 import useClick from "./useClick";
 import useKeyPress from "./useKeyPress";
 
-export { useAnimation, useAppState, useAudio, useKeyPress, useClick };
+export {
+  useAnimation,
+  useAppState,
+  useAudio,
+  useAudioContext,
+  useKeyPress,
+  useClick,
+};

--- a/src/hooks/useAudioContext.tsx
+++ b/src/hooks/useAudioContext.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+declare global {
+  interface Window {
+    webkitAudioContext: typeof AudioContext;
+  }
+}
+
+// this hook encapulates instantiating an AudioContext object. This appears to
+// greatly reduce audio latency on iOS/Safari
+
+export default function useAudioContext() {
+  useEffect(() => {
+    if (!window) return;
+    const AudioContext = window.AudioContext || window.webkitAudioContext;
+    const audioCtx = new AudioContext();
+  }, []);
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,11 +6,12 @@ import {
   KeybindVisibilityToggle,
   LarasSelector,
 } from "@/components";
-import { useAppState } from "@/hooks";
+import { useAppState, useAudioContext } from "@/hooks";
 
 export default function Home() {
   const state = useAppState();
   const { showKeybinds, setShowKeybinds, laras, setLaras } = state;
+  useAudioContext();
 
   return (
     <div className="flex flex-col w-screen h-screen overflow-hidden">


### PR DESCRIPTION
This PR implements the `useAudioContext()` hook which implements an AudioContext. This context isn't used anywhere, but instantiating it appears to improve audio playback latency on Safari considerably