### PR TITLE
Bugfix: Header Styles on Safari

### DIFF
--- a/src/components/InformationModal.tsx
+++ b/src/components/InformationModal.tsx
@@ -10,11 +10,14 @@ export default function InformationModal() {
     <>
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="h-full hidden xs:block aspect-square p-1 sm:p-2 bg-red-800 hover:bg-red-700 focus-visible:ring ring-black focus:bg-red-700 transition-color outline-none "
+        className="h-full w-8 sm:w-12 hidden xs:block aspect-square p-1 sm:p-2 bg-red-800 hover:bg-red-700 focus-visible:ring ring-black focus:bg-red-700 transition-color outline-none "
         aria-label="Open Application Instructions"
         role="button"
       >
-        <Icon svgData={infoIconSvgData} className="fill-white m-1" />
+        <Icon
+          svgData={infoIconSvgData}
+          className="fill-white m-1 not-sr-only"
+        />
       </button>
 
       {/* Modal Menu */}

--- a/src/components/KeybindVisibilityToggle.tsx
+++ b/src/components/KeybindVisibilityToggle.tsx
@@ -15,7 +15,7 @@ export default function KeybindVisibilityToggle({
 
   return (
     <button
-      className={`h-full w-8 sm:w-12 transition-colors mr-1 hover:bg-red-700 outline-none focus-visible:ring ring-black ${
+      className={`h-full w-8 sm:w-12 transition-colors mr-1 focus-visible:bg-red-700  hover:bg-red-700 outline-none focus-visible:ring ring-black ${
         showKeybinds ? "bg-gray-700" : "bg-red-800"
       }`}
       onClick={() => setShowKeybinds(!showKeybinds)}

--- a/src/components/LarasSelector.tsx
+++ b/src/components/LarasSelector.tsx
@@ -38,7 +38,7 @@ export default function LarasSelector({ state }: LarasSelectorProps) {
       {/* Drop Down Menu */}
       <select
         onChange={onLarasChange}
-        className="leading-none px-4 text-sm mr-0.5 sm:text-lg h-full hover:bg-red-700 text-white bg-red-800 tracking-wider outline-none focus-visible:ring ring-black"
+        className="select rounded-none transition-color pr-6 sm:px-4 text-xs sm:w-64 sm:text-lg h-full hover:bg-red-700 text-white bg-red-800 tracking-wider outline-none focus-visible:bg-red-700 focus-visible:ring ring-black"
         aria-label="Laras (Tuning) Dropdown"
         id="laras-selector"
       >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,17 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  .select {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background: transparent;
+    background-image: url("data:image/svg+xml;utf8,<svg fill='white' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>");
+    background-repeat: no-repeat;
+    background-position-x: 100%;
+    background-position-y: 50%;
+    overflow: hidden;
+  }
+}


### PR DESCRIPTION
This PR closes #10. The website header styles are now consistant across Firefox, Chrome and Safari.

This required adding a few additional Tailwind util classes, and creating a more comprehensive CSS reset of the `<select>` element.