### PR TITLE
Feature: useTouch

### DIFF
--- a/src/components/BonangPot.tsx
+++ b/src/components/BonangPot.tsx
@@ -1,6 +1,12 @@
 import { useRef, useState } from "react";
 import { Note } from "@/types";
-import { useAnimation, useAudio, useKeyPress } from "@/hooks";
+import {
+  useAnimation,
+  useAudio,
+  useClick,
+  useKeyPress,
+  useTouch,
+} from "@/hooks";
 import { kepatihanSymbolToText } from "@/utils";
 import { bonangSvgData } from "../../public/graphics";
 import Icon from "./Icon";
@@ -30,10 +36,15 @@ export default function BonangPot({
     animationClass: "animate-pulse",
   });
 
+  // register startStart() method on touch & mousedown
+  const btn = useRef(null);
+  useTouch(btn, () => startSound());
+  useClick(btn, () => startSound());
+
   return (
     <button
       className="w-full flex relative px-2 py-1 aspect-square rounded-full bg-red-50 flex-col justify-center outline-none focus-visible:ring ring-offset-4 ring-red-800"
-      onClick={startSound}
+      ref={btn}
     >
       <Icon
         svgData={bonangSvgData}

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -4,6 +4,7 @@ import useAppState from "./useAppState";
 import useAudio from "./useAudio";
 import useClick from "./useClick";
 import useKeyPress from "./useKeyPress";
+import useTouch from "./useTouch";
 
 export {
   useAnimation,
@@ -12,4 +13,5 @@ export {
   useAudioContext,
   useKeyPress,
   useClick,
+  useTouch,
 };

--- a/src/hooks/useClick.tsx
+++ b/src/hooks/useClick.tsx
@@ -7,12 +7,17 @@ export default function useClick(
 ) {
   useEffect(() => {
     if (!ref.current) return;
-
+    const element = ref.current;
     const onClick = (e: Event) => {
+      e.preventDefault();
       callback();
-      return () => ref.current?.removeEventListener("mousedown", onClick);
     };
 
-    ref.current.addEventListener("mousedown", onClick);
+    // register event listener & cleanup
+
+    element.addEventListener("mousedown", onClick);
+    return () => {
+      element.removeEventListener("mousedown", onClick);
+    };
   }, [ref, callback]);
 }

--- a/src/hooks/useClick.tsx
+++ b/src/hooks/useClick.tsx
@@ -8,16 +8,26 @@ export default function useClick(
   useEffect(() => {
     if (!ref.current) return;
     const element = ref.current;
-    const onClick = (e: Event) => {
+
+    // Event handler for executing callback function
+    const onClick = (e: Event | KeyboardEvent) => {
       e.preventDefault();
       callback();
     };
 
-    // register event listener & cleanup
+    // Triggers a click when element is focused & spacebar is pressed
+    const onFocusClick = (e: KeyboardEvent) => {
+      if (document.activeElement !== ref.current) return;
+      if (e.code !== "Space") return;
+      onClick(e as KeyboardEvent);
+    };
 
+    // register event listener & cleanup
     element.addEventListener("mousedown", onClick);
+    element.addEventListener("keydown", onFocusClick);
     return () => {
       element.removeEventListener("mousedown", onClick);
+      element.removeEventListener("keydown", onFocusClick);
     };
   }, [ref, callback]);
 }

--- a/src/hooks/useClick.tsx
+++ b/src/hooks/useClick.tsx
@@ -11,23 +11,23 @@ export default function useClick(
 
     // Event handler for executing callback function
     const onClick = (e: Event | KeyboardEvent) => {
-      e.preventDefault();
+      e.preventDefault(); // prevents focusing on element
       callback();
     };
+    element.addEventListener("mousedown", onClick);
 
     // Triggers a click when element is focused & spacebar is pressed
     const onFocusClick = (e: KeyboardEvent) => {
-      if (document.activeElement !== ref.current) return;
+      if (document.activeElement !== element) return;
       if (e.code !== "Space") return;
-      onClick(e as KeyboardEvent);
+      callback();
     };
+    window.addEventListener("keydown", onFocusClick);
 
-    // register event listener & cleanup
-    element.addEventListener("mousedown", onClick);
-    element.addEventListener("keydown", onFocusClick);
+    // clean-up
     return () => {
       element.removeEventListener("mousedown", onClick);
-      element.removeEventListener("keydown", onFocusClick);
+      window.removeEventListener("keydown", onFocusClick);
     };
   }, [ref, callback]);
 }

--- a/src/hooks/useClick.tsx
+++ b/src/hooks/useClick.tsx
@@ -9,11 +9,10 @@ export default function useClick(
     if (!ref.current) return;
 
     const onClick = (e: Event) => {
-      if (e.target !== ref.current) return;
       callback();
-      return () => ref.current?.removeEventListener("click", onClick);
+      return () => ref.current?.removeEventListener("mousedown", onClick);
     };
 
-    ref.current.addEventListener("click", onClick);
+    ref.current.addEventListener("mousedown", onClick);
   }, [ref, callback]);
 }

--- a/src/hooks/useTouch.tsx
+++ b/src/hooks/useTouch.tsx
@@ -8,7 +8,7 @@ export default function useTouch(
     if (!ref.current) return;
 
     const onTouch = (e: Event) => {
-      console.log("touch");
+      e.preventDefault(); // prevents also raising a mousedown event
       callback();
       return () => ref.current?.removeEventListener("touchstart", onTouch);
     };

--- a/src/hooks/useTouch.tsx
+++ b/src/hooks/useTouch.tsx
@@ -10,9 +10,11 @@ export default function useTouch(
     const onTouch = (e: Event) => {
       e.preventDefault(); // prevents also raising a mousedown event
       callback();
-      return () => ref.current?.removeEventListener("touchstart", onTouch);
     };
-
-    ref.current.addEventListener("touchstart", onTouch);
+    
+    // register event listener & cleanup
+    const element = ref.current;
+    element.addEventListener("touchstart", onTouch);
+    return () => element.removeEventListener("touchstart", onTouch);
   }, [ref, callback]);
 }

--- a/src/hooks/useTouch.tsx
+++ b/src/hooks/useTouch.tsx
@@ -1,0 +1,18 @@
+import { MutableRefObject, useEffect } from "react";
+
+export default function useTouch(
+  ref: MutableRefObject<null | EventTarget>,
+  callback: Function
+) {
+  useEffect(() => {
+    if (!ref.current) return;
+
+    const onTouch = (e: Event) => {
+      console.log("touch");
+      callback();
+      return () => ref.current?.removeEventListener("touchstart", onTouch);
+    };
+
+    ref.current.addEventListener("touchstart", onTouch);
+  }, [ref, callback]);
+}


### PR DESCRIPTION
This PR closes #12 by refactoring the `onClick` attribute of the button element of the `<BonangPot />` component with custom hooks, as buttons will execute their onClick callback only once the mouse has been released. This feels weird for a musical instrument.

The solution was to use the `useClick()` hook to handle mousedown events. This however caused the application to not work on touchscreens, where pressing on the screen doesn't raise a `mousedown` event but a `touchstart` event. The `useTouch()` hook was implemented to handle firing a callback function when the touchscreen was interacted with. Additionally, the `useClick()` hook was further modified to handle executing a callback function when an the element is focused and the spacebar pressed–functionality that is normally handled by the button element