### PR TITLE
Bugfix: overflows on mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       "devDependencies": {
         "autoprefixer": "^10.4.15",
         "postcss": "^8.4.29",
-        "tailwindcss": "^3.3.3"
+        "tailwindcss": "^3.4.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3665,9 +3665,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.3.tgz",
-      "integrity": "sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
+      "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
       "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -3675,10 +3675,10 @@
         "chokidar": "^3.5.3",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.2.12",
+        "fast-glob": "^3.3.0",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.18.2",
+        "jiti": "^1.19.1",
         "lilconfig": "^2.1.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "devDependencies": {
     "autoprefixer": "^10.4.15",
     "postcss": "^8.4.29",
-    "tailwindcss": "^3.3.3"
+    "tailwindcss": "^3.4.1"
   }
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,7 +4,7 @@ import { githubLogoSvgData } from "../../public/graphics";
 export default function Footer() {
   return (
     <footer
-      className="text-center h-4 xs:h-8 text-xs bg-red-800 text-white font-thin"
+      className="text-center h-4 xs:h-8 text-xs bg-red-800 text-white font-thin wide:hidden"
       aria-label="footer"
     >
       <span>Made with love by </span>

--- a/src/components/InformationModal.tsx
+++ b/src/components/InformationModal.tsx
@@ -22,45 +22,62 @@ export default function InformationModal() {
 
       {/* Modal Menu */}
       {isOpen && (
-        <article
-          className="absolute bg-white/90 m-10 z-10 w-96 p-4 border-black border"
-          onClick={() => setIsOpen(false)}
-          aria-label="Application Instructions"
-          role="presentation"
-        >
-          <h2 className="text-center uppercase text-xl font-bold text-red-800">
-            Instructions
-          </h2>
-          <section
-            className="text-sm md:text-base outline-none focus-visible:ring ring-red-800"
-            tabIndex={0}
-          >
-            <h3 className="font-bold uppercase">To Play</h3>
-            <p className="mb-2">
-              Click on the pots below or use your keyboard (Q to U for the top
-              row, A to J for the bottom)
-            </p>
-            <h3 className="font-bold uppercase">What is the Bonang?</h3>
-            <p className="mb-2">
-              The Bonang is an instrument in the Javanese Gamelan. It is formed
-              of two rows of small tuned gong chimes arranged horizontally and
-              played with a pair of padded mallets.
-            </p>
+        <>
+          {/* shade over rest of page */}
+          <div
+            className="absolute w-screen h-screen sm:visible bg-gray-800/30 z-10"
+            onClick={() => setIsOpen(false)}
+          />
 
-            <h3 className="font-bold uppercase">Notes</h3>
-            <p className="mb-2">
-              Notes in gamelan are numbered from 1 to 7. A dot below or above
-              indicates the same note but at a high or lower register/octave.
-            </p>
-            <h3 className="font-bold uppercase">Laras</h3>
-            <p className="mb-2">
-              Laras can be loosely translated from Javanese as tuning system.
-              There are two laras in Javanese gamelan; laras slendro, which has
-              5 notes, and laras pelog, which has 7.
-            </p>
-          </section>
-        </article>
+          {/* modal content */}
+          <div
+            className="absolute bg-white/95 z-10 w-screen px-4 py-3 wide:w-screen sm:top-12 sm:w-2/5  border-red-800 border"
+            onClick={() => setIsOpen(false)}
+            aria-label="Application Instructions"
+            role="presentation"
+          >
+            <article
+              className="text-sm flex flex-col gap-2 wide:gap-1 md:text-base overflow-y-auto outline-none focus-visible:ring ring-red-800"
+              tabIndex={0}
+            >
+              {copy.map((paragraph, i) => (
+                <section key={i} className="text-sm md:text-base">
+                  <h2 className="font-bold text-red-800 text-lg wide:text-base font-serif">
+                    {paragraph.title}
+                  </h2>
+                  <p className="wide:text-sm">{paragraph.content}</p>
+                </section>
+              ))}
+            </article>
+          </div>
+        </>
       )}
     </>
   );
 }
+
+const copy = [
+  {
+    title: "Instructions",
+    content: `Click on the pots or use your keyboard (Q to U for the top
+      row, A to J for the bottom) to make music.`,
+  },
+  {
+    title: "What is the Bonang?",
+    content: `The Bonang is an instrument in the Javanese Gamelan. It is 
+    formed of two rows of small bronze gong chimes arranged in a wooden rack
+     and is played with a pair of padded mallets.`,
+  },
+
+  {
+    title: "Notes",
+    content: `Notes in gamelan are numbered from 1 to 7. A dot below or above
+    indicates the same note but at a high or lower register/octave.`,
+  },
+  {
+    title: "Laras",
+    content: `Laras is a Javanese word for tuning. There are two laras used in
+    gamelan music, SLENDRO & PELOG. A complete gamelan is usually a double set
+     of instruments, one for each laras.`,
+  },
+];

--- a/src/components/InformationModal.tsx
+++ b/src/components/InformationModal.tsx
@@ -10,7 +10,7 @@ export default function InformationModal() {
     <>
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="h-full w-8 sm:w-12 hidden xs:block aspect-square p-1 sm:p-2 bg-red-800 hover:bg-red-700 focus-visible:ring ring-black focus:bg-red-700 transition-color outline-none "
+        className="h-full w-8 sm:w-12 wide:w-8 wide:h-8 hidden xs:block aspect-square p-1 sm:p-2 wide:p-1 bg-red-800 hover:bg-red-700 focus-visible:ring ring-black focus:bg-red-700 transition-color outline-none "
         aria-label="Open Application Instructions"
         role="button"
       >

--- a/src/components/InformationModal.tsx
+++ b/src/components/InformationModal.tsx
@@ -31,7 +31,7 @@ export default function InformationModal() {
 
           {/* modal content */}
           <div
-            className="absolute bg-white/95 z-10 w-screen px-4 py-3 wide:w-screen sm:top-12 sm:w-2/5  border-red-800 border"
+            className="absolute bg-white/95 z-10 w-screen px-4 py-3 sm:top-12 sm:w-3/5 wide:top-8 wide:w-screen border-red-800 border overflow-x-hidden"
             onClick={() => setIsOpen(false)}
             aria-label="Application Instructions"
             role="presentation"
@@ -41,7 +41,7 @@ export default function InformationModal() {
               tabIndex={0}
             >
               {copy.map((paragraph, i) => (
-                <section key={i} className="text-sm md:text-base">
+                <section key={i} className="text-sm lg:text-base">
                   <h2 className="font-bold text-red-800 text-lg wide:text-base font-serif">
                     {paragraph.title}
                   </h2>

--- a/src/components/KeybindVisibilityToggle.tsx
+++ b/src/components/KeybindVisibilityToggle.tsx
@@ -15,7 +15,7 @@ export default function KeybindVisibilityToggle({
 
   return (
     <button
-      className={`h-full w-8 sm:w-12 transition-colors mr-1 focus-visible:bg-red-700  hover:bg-red-700 outline-none focus-visible:ring ring-black ${
+      className={`h-full w-8 sm:w-12 wide:w-8 transition-colors mr-1 focus-visible:bg-red-700  hover:bg-red-700 outline-none focus-visible:ring ring-black ${
         showKeybinds ? "bg-gray-700" : "bg-red-800"
       }`}
       onClick={() => setShowKeybinds(!showKeybinds)}

--- a/src/components/LarasSelector.tsx
+++ b/src/components/LarasSelector.tsx
@@ -28,7 +28,7 @@ export default function LarasSelector({ state }: LarasSelectorProps) {
       <div className="p-0 m-0 flex items-center">
         <label
           aria-hidden="true"
-          className="bg-white max-w-min uppercase whitespace-nowrap font-bold text-red-800 px-1 text-2xs sm:text-xs border-red-800"
+          className="bg-white max-w-min uppercase whitespace-nowrap font-bold text-red-800 px-1 text-2xs sm:text-xs wide:text-2xs border-red-800"
         >
           Laras / Tuning
         </label>
@@ -38,7 +38,7 @@ export default function LarasSelector({ state }: LarasSelectorProps) {
       {/* Drop Down Menu */}
       <select
         onChange={onLarasChange}
-        className="select rounded-none transition-color pr-6 sm:px-4 text-xs sm:w-64 sm:text-lg h-full hover:bg-red-700 text-white bg-red-800 tracking-wider outline-none focus-visible:bg-red-700 focus-visible:ring ring-black"
+        className="select rounded-none transition-color pr-6 w-40 wide:w-40 wide:pr-4 text-xs sm:w-64 sm:text-lg wide:text-xs h-full hover:bg-red-700 text-white bg-red-800 tracking-wider outline-none focus-visible:bg-red-700 focus-visible:ring ring-black"
         aria-label="Laras (Tuning) Dropdown"
         id="laras-selector"
       >

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,8 +11,8 @@ const kepatihanFont = localFont({
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <main className={kepatihanFont.variable}>
+    <div className={kepatihanFont.variable}>
       <Component {...pageProps} />
-    </main>
+    </div>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -36,7 +36,7 @@ export default function Home() {
       </header>
 
       <main
-        className="mb-auto mt-auto mx-5 hidden xs:block"
+        className="mb-auto mt-auto mx-5 hidden xs:block overflow-y-hidden"
         aria-label="Application"
       >
         <Bonang state={state} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,7 +22,7 @@ export default function Home() {
       >
         {/* Left side of banner */}
         <div className="flex flex-row w-full">
-          <h1 className="inline align-middle whitespace-nowrap uppercase font-bold h-full sm:text-xl sm:pt-2 p-1 bg-red-800 px-4 text-white">
+          <h1 className="inline align-middle whitespace-nowrap uppercase font-bold h-full sm:text-xl sm:pt-2 p-1  px-4 text-white">
             Virtual Bonang
           </h1>
           <InformationModal />
@@ -36,13 +36,13 @@ export default function Home() {
       </header>
 
       <main
-        className="mb-auto mt-auto mx-5 hidden landscape:block xs:block"
+        className="mb-auto mt-auto mx-5 hidden xs:block"
         aria-label="Application"
       >
         <Bonang state={state} />
       </main>
 
-      <main className="mb-auto p-2 mt-auto block  uppercase font-bold text-center  xs:hidden landscape:hidden">
+      <main className="mb-auto p-2 mt-auto block  uppercase font-bold text-center xs:hidden">
         <p className="text-3xl font-sans">Please orientate your device wide</p>
         <p className="mt-2 tracking-tight">The bonang is a wide instrument</p>
       </main>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,12 +17,12 @@ export default function Home() {
     <div className="flex flex-col w-screen h-screen overflow-hidden">
       <Seo />
       <header
-        className="flex justify-between h-8 sm:h-12 bg-red-800"
+        className="flex justify-between h-8 sm:h-12 wide:h-8 bg-red-800"
         aria-label="Application Header & Settings"
       >
         {/* Left side of banner */}
         <div className="flex flex-row w-full">
-          <h1 className="inline align-middle whitespace-nowrap uppercase font-bold h-full sm:text-xl sm:pt-2 p-1  px-4 text-white">
+          <h1 className="inline align-middle whitespace-nowrap uppercase font-bold h-full sm:text-xl wide:text-base wide:pt-1 sm:pt-2 p-1  px-4 text-white">
             Virtual Bonang
           </h1>
           <InformationModal />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,14 +8,17 @@ module.exports = {
   ],
   theme: {
     extend: {
-      fontSize: {
-        "2xs": "0.5rem",
-      },
       animation: {
         pulse: "pulse 0.1s ease-in-out",
       },
       fontFamily: {
         kepatihan: ["var(--font-kepatihan)"],
+      },
+      fontSize: {
+        "2xs": "0.5rem",
+      },
+      height: {
+        screen: ["100vh /* fallback for older browers */", "100dvh"],
       },
       keyframes: {
         pulse: {
@@ -25,6 +28,9 @@ module.exports = {
       },
       screens: {
         xs: "420px",
+      },
+      width: {
+        screen: ["100vw /* fallback for older browers */", "100dvw"],
       },
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,6 +27,7 @@ module.exports = {
         },
       },
       screens: {
+        wide: { raw: "(max-height: 428px)" },
         xs: "420px",
       },
       width: {


### PR DESCRIPTION
Closes #16 

This PR addresses the weird overflow behaviours on mobile in a several ways:

- Updating overflow CSS propertes on problem elements
- Adding a vertical breakpoint that targets mobile landscape screen size, and conditional styles to reduce content height at this resolution
- Refactoring the `InformationModal` component so that the content both fits better on a single screen at most resolutions, and that the only the modal overflows when content is too large for the screen (instead of the whole page overflowing)